### PR TITLE
fix: 修复@types/node包版本问题，修复@types/joi包不存在问题

### DIFF
--- a/integration/vue2/boilerplate/package.json
+++ b/integration/vue2/boilerplate/package.json
@@ -17,8 +17,9 @@
   },
   "devDependencies": {
     "@midwayjs/serverless-invoke": "^1.0.0",
+    "@types/joi": "^14.3.4",
     "@types/mocha": "^7.0.2",
-    "@types/node": "^14.0.1",
+    "@types/node": "~14.0.1",
     "@typescript-eslint/eslint-plugin": "^2.26.0",
     "@typescript-eslint/parser": "^2.26.0",
     "@vue/cli-plugin-babel": "~4.3.0",


### PR DESCRIPTION
目前vue2的demo下载下来后运行会报错，经排查，少了一个包【@types/joi】，并且@types/node的版本目前最新版本会有@types/node Class 'Module' incorrectly implements interface 'NodeModule'.的错误，需要修改一下@types/node的版本,可以合一下我的PR

报错详情：
```
ERROR in /github/midway-serverless-examples/integration/vue2/boilerplate/node_modules/@midwayjs/decorator/dist/annotation/rule.d.ts(1,22):
1:22 Could not find a declaration file for module 'joi'. '/Users/xinying/Documents/workspace/github/midway-serverless-examples/integration/vue2/boilerplate/node_modules/joi/lib/index.js' implicitly has an 'any' type.
  Try `npm install @types/joi` if it exists or add a new declaration (.d.ts) file containing `declare module 'joi';`
  > 1 | import * as joi from 'joi';
      |                      ^
    2 | export declare function Rule(rule: any): (target: any, propertyKey: string) => void;
    3 | export { joi as RuleType };
    4 | //# sourceMappingURL=rule.d.ts.map
ERROR in /github/midway-serverless-examples/integration/vue2/boilerplate/node_modules/@types/node/globals.d.ts(581,15):
581:15 Interface 'NodeJS.Module' incorrectly extends interface '__WebpackModuleApi.Module'.
  Types of property 'parent' are incompatible.
    Type 'Module | null | undefined' is not assignable to type 'NodeModule | null'.
      Type 'undefined' is not assignable to type 'NodeModule | null'.
    579 |         '.node': (m: Module, filename: string) => any;
    580 |     }
  > 581 |     interface Module {
        |               ^
    582 |         exports: any;
    583 |         require: Require;
    584 |         id: string;
```